### PR TITLE
Replace remaining custom memory allocation calls

### DIFF
--- a/Quake/pl_osx.m
+++ b/Quake/pl_osx.m
@@ -50,7 +50,7 @@ char *PL_GetClipboardData (void)
 	if (clipboardString != NULL && [clipboardString length] > 0) {
 		size_t sz = [clipboardString length] + 1;
 		sz = q_min(MAX_CLIPBOARDTXT, sz);
-		data = (char *) Z_Malloc(sz);
+		data = (char *) Mem_Alloc(sz);
 		q_strlcpy (data, [clipboardString cStringUsingEncoding: NSASCIIStringEncoding], sz);
 	}
     }

--- a/Quake/snd_modplug.c
+++ b/Quake/snd_modplug.c
@@ -61,16 +61,14 @@ static qboolean S_MODPLUG_CodecOpenStream (snd_stream_t *stream)
 	/* need to load the whole file into memory and pass it to libmodplug */
 	byte *moddata;
 	long  len;
-	int   mark;
 
 	len = FS_filelength (&stream->fh);
-	mark = Hunk_LowMark ();
 	moddata = (byte *)Mem_Alloc (len);
 	FS_fread (moddata, 1, len, &stream->fh);
 
 	S_MODPLUG_SetSettings (stream);
 	stream->priv = ModPlug_Load (moddata, len);
-	Hunk_FreeToLowMark (mark); /* free original file data */
+	Mem_Free (moddata); /* free original file data */
 	if (!stream->priv)
 	{
 		Con_DPrintf ("Could not load module %s\n", stream->name);

--- a/Quake/snd_xmp.c
+++ b/Quake/snd_xmp.c
@@ -70,7 +70,6 @@ static qboolean S_XMP_CodecOpenStream (snd_stream_t *stream)
 #else
 	byte *moddata;
 	long  len;
-	int   mark;
 #endif
 	int fmt;
 
@@ -86,7 +85,6 @@ static qboolean S_XMP_CodecOpenStream (snd_stream_t *stream)
 	}
 #else
 	len = FS_filelength (&stream->fh);
-	mark = Hunk_LowMark ();
 	moddata = (byte *)Mem_Alloc (len);
 	FS_fread (moddata, 1, len, &stream->fh);
 	if (xmp_load_module_from_memory (c, moddata, len) < 0)
@@ -94,7 +92,7 @@ static qboolean S_XMP_CodecOpenStream (snd_stream_t *stream)
 		Con_DPrintf ("Could not load module %s\n", stream->name);
 		goto err1;
 	}
-	Hunk_FreeToLowMark (mark); /* free original file data */
+	Mem_Free (moddata); /* free original file data */
 #endif
 
 	stream->priv = c;


### PR DESCRIPTION
These files are not compiled by default, so continuous integration build didn't detect any issues with them